### PR TITLE
No longer need file permission.

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -20,9 +20,6 @@
     <!-- To fetch the api calls over HTTP -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- To persist the location in a file for subsequent look-up -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
@mrosack removed the need for a file based storage with aa04d9589e74e1163986308c7f312e863507f317

This commit removes it from the permission manifest.

Updates #34 by reducing the permissions required to only `android.permission.INTERNET`
